### PR TITLE
ovn/endpoints: ignore headless ClusterIP services

### DIFF
--- a/go-controller/pkg/ovn/endpoints.go
+++ b/go-controller/pkg/ovn/endpoints.go
@@ -25,6 +25,10 @@ func (ovn *Controller) AddEndpoints(ep *kapi.Endpoints) error {
 			ep.Name, ep.Namespace)
 		return nil
 	}
+	if !util.IsServiceIPSet(svc) {
+		logrus.Debugf("Skipping service %s due to clusterIP = %q", svc.Name, svc.Spec.ClusterIP)
+		return nil
+	}
 	tcpPortMap := make(map[string]lbEndpoints)
 	udpPortMap := make(map[string]lbEndpoints)
 	for _, s := range ep.Subsets {
@@ -141,6 +145,9 @@ func (ovn *Controller) deleteEndpoints(ep *kapi.Endpoints) error {
 		// will fail.
 		logrus.Debugf("no service found for endpoint %s in namespace %s",
 			ep.Name, ep.Namespace)
+		return nil
+	}
+	if !util.IsServiceIPSet(svc) {
 		return nil
 	}
 	for _, svcPort := range svc.Spec.Ports {

--- a/go-controller/pkg/ovn/service.go
+++ b/go-controller/pkg/ovn/service.go
@@ -5,11 +5,8 @@ import (
 	"github.com/sirupsen/logrus"
 	kapi "k8s.io/api/core/v1"
 	"net"
+	"github.com/openvswitch/ovn-kubernetes/go-controller/pkg/util"
 )
-
-func isServiceIPSet(service *kapi.Service) bool {
-	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
-}
 
 func (ovn *Controller) syncServices(services []interface{}) {
 	// For all clusterIP in k8s, we will populate the below slice with
@@ -43,7 +40,7 @@ func (ovn *Controller) syncServices(services []interface{}) {
 			continue
 		}
 
-		if !isServiceIPSet(service) {
+		if !util.IsServiceIPSet(service) {
 			logrus.Debugf("Skipping service %s due to clusterIP = %q",
 				service.Name, service.Spec.ClusterIP)
 			continue
@@ -170,7 +167,7 @@ func (ovn *Controller) syncServices(services []interface{}) {
 }
 
 func (ovn *Controller) deleteService(service *kapi.Service) {
-	if !isServiceIPSet(service) || len(service.Spec.Ports) == 0 {
+	if !util.IsServiceIPSet(service) || len(service.Spec.Ports) == 0 {
 		return
 	}
 

--- a/go-controller/pkg/util/util.go
+++ b/go-controller/pkg/util/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	kapi "k8s.io/api/core/v1"
 
 	"github.com/urfave/cli"
 )
@@ -30,4 +31,10 @@ func FetchIfMacWindows(interfaceName string) (string, error) {
 	macAddress := strings.Replace(strings.TrimSpace(fmt.Sprintf("%s", stdoutStderr)), "-", ":", -1)
 
 	return strings.ToLower(macAddress), nil
+}
+
+// IsServiceIPSet checks if the service is headless service, if yes,
+// return False, otherwise reteurn True
+func IsServiceIPSet(service *kapi.Service) bool {
+	return service.Spec.ClusterIP != kapi.ClusterIPNone && service.Spec.ClusterIP != ""
 }


### PR DESCRIPTION
We should ignore adding vip load balancer rules for headless
ClusterIP services which have "None" as the Cluster IP.

Signed-off-by: Yun Zhou <yunz@nvidia.com>