### PR TITLE
call out the protocol to be TCP for north-south load-balancer

### DIFF
--- a/go-controller/pkg/cluster/gateway_init_linux_test.go
+++ b/go-controller/pkg/cluster/gateway_init_linux_test.go
@@ -30,7 +30,7 @@ func addNodeportLBs(nodeName, tcpLBUUID, udpLBUUID string, fakeCmds []fakeexec.F
 		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=_uuid find load_balancer external_ids:TCP_lb_gateway_router=GR_" + nodeName,
 	})
 	fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
-		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:TCP_lb_gateway_router=GR_" + nodeName,
+		Cmd:    "ovn-nbctl --timeout=15 -- create load_balancer external_ids:TCP_lb_gateway_router=GR_" + nodeName + " protocol=tcp",
 		Output: tcpLBUUID,
 	})
 	fakeCmds = ovntest.AddFakeCmdsNoOutputNoError(fakeCmds, []string{

--- a/go-controller/pkg/util/gateway-init.go
+++ b/go-controller/pkg/util/gateway-init.go
@@ -240,7 +240,8 @@ func GatewayInit(clusterIPSubnet []string, nodeName, nicIP, physicalInterface,
 		if k8sNSLbTCP == "" {
 			k8sNSLbTCP, stderr, err = RunOVNNbctl("--", "create",
 				"load_balancer",
-				"external_ids:TCP_lb_gateway_router="+gatewayRouter)
+				"external_ids:TCP_lb_gateway_router="+gatewayRouter,
+				"protocol=tcp")
 			if err != nil {
 				return fmt.Errorf("Failed to create load balancer: "+
 					"stderr: %q, error: %v", stderr, err)


### PR DESCRIPTION
without setting 'protocol=tcp' for north-south load-balancer, the output
of `onv-ncbtl lb-list` displays 'null' instead of 'tcp'.

Signed-off-by: Girish Moodalbail <gmoodalbail@nvidia.com>