### PR TITLE
ovn: wait until node switch appears before creating the management port

### DIFF
--- a/go-controller/pkg/ovn/management-port_test.go
+++ b/go-controller/pkg/ovn/management-port_test.go
@@ -79,6 +79,9 @@ var _ = Describe("Management Port Operations", func() {
 				Output: mgtPortMAC,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
+				Cmd: "ovn-nbctl --timeout=15 get logical_switch " + nodeName + " other-config",
+			})
+			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{
 				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP,
 			})
 			fakeCmds = ovntest.AddFakeCmd(fakeCmds, &ovntest.ExpectedCmd{


### PR DESCRIPTION
Today, ovnkube-node checks the existence of the "ovn_host_subnet"
annotation to assure that ovnkube-master is up and running. This can
cause problems as the annotation was not cleaned up when one attempts to
deleting/recreating ovnkube-master deployment without recreating the k8s
cluster. Although this can be considered as a user error, it would
always be better to regard OVN DB as the source of truth instead and
check that.

Signed-off-by: Yun Zhou <yunz@nvidia.com>