### PR TITLE
remove statically allocated IP from switch's exclude_ips configuration

### DIFF
--- a/go-controller/pkg/ovn/management-port.go
+++ b/go-controller/pkg/ovn/management-port.go
@@ -250,12 +250,16 @@ func CreateManagementPort(nodeName, localSubnet string, clusterSubnet []string) 
 		}
 	}
 
-	// Create this node's management logical port on the node switch
+	// Create this node's management logical port on the node switch, now the second subnet IP is statically allocated
+	// to the management logical port, we can safely remove the other_config:excluded_ips in the same transaction to
+	// avoid northd duplicate IP set warnings.
 	ip = util.NextIP(ip)
 	portIP := ip.String()
 	n, _ := subnet.Mask.Size()
 	portIPMask := fmt.Sprintf("%s/%d", portIP, n)
-	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "k8s-"+nodeName, "--", "lsp-set-addresses", "k8s-"+nodeName, macAddress+" "+portIP)
+	stdout, stderr, err = util.RunOVNNbctl("--", "--may-exist", "lsp-add", nodeName, "k8s-"+nodeName, "--",
+		"lsp-set-addresses", "k8s-"+nodeName, macAddress+" "+portIP, "--", "--if-exists", "remove", "logical_switch",
+		nodeName, "other-config", "exclude_ips")
 	if err != nil {
 		logrus.Errorf("Failed to add logical port to switch, stdout: %q, stderr: %q, error: %v", stdout, stderr, err)
 		return err

--- a/go-controller/pkg/ovn/management-port_test.go
+++ b/go-controller/pkg/ovn/management-port_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Management Port Operations", func() {
 				Output: mgtPortMAC,
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP,
+				Cmd: "ovn-nbctl --timeout=15 -- --may-exist lsp-add " + nodeName + " " + mgtPort + " -- lsp-set-addresses " + mgtPort + " " + mgtPortMAC + " " + mgtPortIP + " -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
 				Cmd:    "ovn-nbctl --timeout=15 lsp-get-addresses stor-" + nodeName,


### PR DESCRIPTION
ovn-northd complains about "Duplicate IP set" if any IP address
configurated in logical switch's other_config:exclude_ips fields is
then staticallly allocated to its logical switch port. To eliminate such
warnings, we'd remove the exclude_ips configuration in the same
transaction when the management port is created.