### PR TITLE
sdn-205 support for custom mac for OVN POD

### DIFF
--- a/go-controller/pkg/cni/cni.go
+++ b/go-controller/pkg/cni/cni.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"time"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -59,6 +60,8 @@ func extractPodBandwidthResources(podAnnotations map[string]string) (int64, int6
 }
 
 func (pr *PodRequest) cmdAdd() *PodResult {
+	var err error
+
 	namespace := pr.PodNamespace
 	podName := pr.PodName
 	if namespace == "" || podName == "" {
@@ -113,6 +116,37 @@ func (pr *PodRequest) cmdAdd() *PodResult {
 	if ipAddress == "" || macAddress == "" || gatewayIP == "" {
 		logrus.Errorf("failed in pod annotation key extract")
 		return nil
+	}
+
+	ipAddressMask := strings.Split(ipAddress, "/")
+	if len(ipAddressMask) != 2 {
+		logrus.Errorf("Error to get ip address")
+		return nil
+	}
+
+	// Pod spec ask for custom MAC address, update the corresponding logical port and the pod annotation
+	if len(pr.MAC) != 0 && pr.MAC != macAddress {
+		logrus.Debugf("cmdAdd: Pod %s/%s request custom MAC %s", namespace, podName, pr.MAC)
+
+		portName := fmt.Sprintf("%s_%s", namespace, podName)
+		out, stderr, err := util.RunOVNNbctl("--wait=sb", "--", "lsp-set-addresses", portName,
+			fmt.Sprintf("%s %s", pr.MAC, ipAddressMask[0]), "--", "lsp-set-port-security", portName,
+			fmt.Sprintf("%s %s", pr.MAC, ipAddress))
+		if err != nil {
+			logrus.Errorf("Error while updating logical port %s's mac address to %s "+
+				"stdout: %q, stderr: %q (%v)",
+				portName, pr.MAC, out, stderr, err)
+			return nil
+		}
+		annotation := fmt.Sprintf(`{\"ip_address\":\"%s\", \"mac_address\":\"%s\", \"gateway_ip\": \"%s\"}`, ipAddress, pr.MAC, gatewayIP)
+		logrus.Debugf("Annotation values: ip=%s ; mac=%s ; gw=%s\nAnnotation=%s", ipAddress, pr.MAC, gatewayIP, annotation)
+		err = kubecli.SetAnnotationOnPod(namespace, podName, "ovn", annotation)
+		if err != nil {
+			logrus.Errorf("Failed to set annotation on pod %s/%s - %v", namespace, podName, err)
+			return nil
+		}
+
+		macAddress = pr.MAC
 	}
 
 	ingress, egress, err := extractPodBandwidthResources(annotation)

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -118,6 +118,11 @@ func cniRequestToPodRequest(r *http.Request) (*PodRequest, error) {
 		return nil, fmt.Errorf("missing K8S_POD_NAMESPACE")
 	}
 
+	req.MAC, ok = cniArgs["MAC"]
+	if !ok {
+		req.MAC = ""
+	}
+
 	req.PodName, ok = cniArgs["K8S_POD_NAME"]
 	if !ok {
 		return nil, fmt.Errorf("missing K8S_POD_NAME")

--- a/go-controller/pkg/cni/cniserver.go
+++ b/go-controller/pkg/cni/cniserver.go
@@ -118,10 +118,7 @@ func cniRequestToPodRequest(r *http.Request) (*PodRequest, error) {
 		return nil, fmt.Errorf("missing K8S_POD_NAMESPACE")
 	}
 
-	req.MAC, ok = cniArgs["MAC"]
-	if !ok {
-		req.MAC = ""
-	}
+	req.MAC, _ = cniArgs["MAC"]
 
 	req.PodName, ok = cniArgs["K8S_POD_NAME"]
 	if !ok {

--- a/go-controller/pkg/cni/types.go
+++ b/go-controller/pkg/cni/types.go
@@ -48,6 +48,8 @@ type PodRequest struct {
 	Netns string
 	// Interface name to be configured
 	IfName string
+	// custom mac
+	MAC string
 	// CNI conf obtained from stdin conf
 	CNIConf *types.NetConf
 	// Channel for returning the operation result to the Server

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -15,7 +15,7 @@ import (
 // Interface represents the exported methods for dealing with getting/setting
 // kubernetes resources
 type Interface interface {
-	SetAnnotationOnPod(pod *kapi.Pod, key, value string) error
+	SetAnnotationOnPod(namespace, name string, key, value string) error
 	SetAnnotationOnNode(node *kapi.Node, key, value string) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)
@@ -33,13 +33,13 @@ type Kube struct {
 	KClient kubernetes.Interface
 }
 
-// SetAnnotationOnPod takes the pod object and key/value string pair to set it as an annotation
-func (k *Kube) SetAnnotationOnPod(pod *kapi.Pod, key, value string) error {
-	logrus.Infof("Setting annotations %s=%s on pod %s", key, value, pod.Name)
+// SetAnnotationOnPod takes the pod namespace/name and key/value string pair to set it as an annotation
+func (k *Kube) SetAnnotationOnPod(namespace, name string, key, value string) error {
+	logrus.Infof("Setting annotations %s=%s on pod %s/%s", key, value, name, namespace)
 	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, key, value)
-	_, err := k.KClient.CoreV1().Pods(pod.Namespace).Patch(pod.Name, types.MergePatchType, []byte(patchData))
+	_, err := k.KClient.CoreV1().Pods(namespace).Patch(name, types.MergePatchType, []byte(patchData))
 	if err != nil {
-		logrus.Errorf("Error in setting annotation on pod %s/%s: %v", pod.Name, pod.Namespace, err)
+		logrus.Errorf("Error in setting annotation on pod %s/%s: %v", name, namespace, err)
 	}
 	return err
 }

--- a/go-controller/pkg/kube/kube.go
+++ b/go-controller/pkg/kube/kube.go
@@ -15,7 +15,7 @@ import (
 // Interface represents the exported methods for dealing with getting/setting
 // kubernetes resources
 type Interface interface {
-	SetAnnotationOnPod(namespace, name string, key, value string) error
+	SetAnnotationOnPod(namespace, name, key, value string) error
 	SetAnnotationOnNode(node *kapi.Node, key, value string) error
 	GetAnnotationsOnPod(namespace, name string) (map[string]string, error)
 	GetPod(namespace, name string) (*kapi.Pod, error)
@@ -34,12 +34,12 @@ type Kube struct {
 }
 
 // SetAnnotationOnPod takes the pod namespace/name and key/value string pair to set it as an annotation
-func (k *Kube) SetAnnotationOnPod(namespace, name string, key, value string) error {
-	logrus.Infof("Setting annotations %s=%s on pod %s/%s", key, value, name, namespace)
+func (k *Kube) SetAnnotationOnPod(namespace, name, key, value string) error {
+	logrus.Infof("Setting annotations %s=%s on pod %s/%s", key, value, namespace, name)
 	patchData := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, key, value)
 	_, err := k.KClient.CoreV1().Pods(namespace).Patch(name, types.MergePatchType, []byte(patchData))
 	if err != nil {
-		logrus.Errorf("Error in setting annotation on pod %s/%s: %v", name, namespace, err)
+		logrus.Errorf("Error in setting annotation on pod %s/%s: %v", namespace, name, err)
 	}
 	return err
 }

--- a/go-controller/pkg/ovn/pods.go
+++ b/go-controller/pkg/ovn/pods.go
@@ -295,7 +295,7 @@ func (oc *Controller) addLogicalPort(pod *kapi.Pod) {
 		podIP.String(), mask, podMac.String(), gatewayIP)
 	logrus.Debugf("Annotation values: ip=%s/%s ; mac=%s ; gw=%s\nAnnotation=%s",
 		podIP.String(), mask, podMac.String(), gatewayIP, annotation)
-	err = oc.kube.SetAnnotationOnPod(pod, "ovn", annotation)
+	err = oc.kube.SetAnnotationOnPod(pod.Namespace, pod.Name, "ovn", annotation)
 	if err != nil {
 		logrus.Errorf("Failed to set annotation on pod %s - %v", pod.Name, err)
 	}


### PR DESCRIPTION
To define the custom mac, one needs to:

1. define the NetworkAttachmentDefinition 

`apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: ovnkube
  namespace: kube-system
spec:
  config: '{
    "cniVersion": "0.3.1",
    "name": "ovn-kubernetes",
    "type": "ovn-k8s-cni-overlay",
    "ipadm": {},
    "dns" : {}
}'`

2. add the folllowing annotation in the Pod yaml:

 ` annotations:
    v1.multus-cni.io/default-network: |
      [
        {
          "name":"ovnkube",
          "namespace":"kube-system",
          "mac": "aa:bb:cc:dd:ee:ff"
        }
      ]`
