### PR TITLE
Error creating Node Management Port if ovn_host_subnet node annotatio…

### DIFF
--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -186,10 +186,7 @@ func updateOVNConfig(ep *kapi.Endpoints) error {
 		return err
 	}
 
-	err = config.UpdateOVNNodeAuth(masterIPList, strconv.Itoa(int(southboundDBPort)), strconv.Itoa(int(northboundDBPort)))
-	if err != nil {
-		return err
-	}
+	config.UpdateOVNNodeAuth(masterIPList, strconv.Itoa(int(southboundDBPort)), strconv.Itoa(int(northboundDBPort)))
 
 	for _, auth := range []config.OvnAuthConfig{config.OvnNorth, config.OvnSouth} {
 		if err := auth.SetDBAuth(); err != nil {

--- a/go-controller/pkg/config/config_test.go
+++ b/go-controller/pkg/config/config_test.go
@@ -989,14 +989,6 @@ mode=shared
 					}
 				})
 
-			generateTests("the OVN URL is a hostname",
-				"OVN DB host \"foobar.org:4444\" must be an IP address, not a DNS name",
-				func() []string {
-					return []string{
-						"address=tcp://foobar.org:4444",
-					}
-				})
-
 			generateTests("certs are provided for the TCP scheme",
 				"certificate or key given; perhaps you mean to use the 'ssl' scheme?",
 				func() []string {

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -463,9 +463,15 @@ func (oc *Controller) WatchNodes() error {
 			if err != nil {
 				logrus.Errorf("error creating subnet for node %s: %v", node.Name, err)
 			}
-			err = oc.syncNodeManagementPort(node)
+			// get the node with the updated annotation set
+			newNode, err := oc.kube.GetNode(node.Name)
 			if err != nil {
-				logrus.Errorf("error creating Node Management Port for node %s: %v", node.Name, err)
+				logrus.Errorf("failed to get the node %s: %v", node.Name, err)
+			} else {
+				err = oc.syncNodeManagementPort(newNode)
+				if err != nil {
+					logrus.Errorf("error creating Node Management Port for node %s: %v", node.Name, err)
+				}
 			}
 			if !config.Gateway.NodeportEnable {
 				return


### PR DESCRIPTION
…n was just created

parseNodeHostSubnet() function directly accesses node's annotation
mapping. When it is called in the same addNode handler function
where the annotation was just set, it would fail.