### PR TITLE
label node with host subnet zone name to specify specific subnet range

### DIFF
--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -29,6 +29,9 @@ const DefaultEncapPort = 6081
 
 const DefaultAPIServer = "http://localhost:8443"
 
+// DefaultNodeSubnetSelectorName captures default name for the node subnet selector
+const DefaultNodeSubnetSelectorName = "default"
+
 // IP address range from which subnet is allocated for per-node join switch
 const (
 	V4JoinSubnet = "100.64.0.0/16"
@@ -145,9 +148,12 @@ type DefaultConfig struct {
 	// RawClusterSubnets holds the unparsed cluster subnets. Should only be
 	// used inside config module.
 	RawClusterSubnets string `gcfg:"cluster-subnets"`
-	// ClusterSubnets holds parsed cluster subnet entries and may be used
+	// ClusterSubnets holds all parsed cluster subnet entries and may be used
 	// outside the config module.
 	ClusterSubnets []CIDRNetworkEntry
+	// ClusterSubnetsBySelector holds all parsed cluster subnet entries keyed by selectorName
+	// and may be used outside the config module.
+	ClusterSubnetsBySelector map[string][]CIDRNetworkEntry
 }
 
 // LoggingConfig holds logging-related parsed config file parameters and command-line overrides
@@ -1040,7 +1046,7 @@ func buildHybridOverlayConfig(ctx *cli.Context, cli, file *config, allSubnets *c
 
 	if HybridOverlay.Enabled {
 		var err error
-		HybridOverlay.ClusterSubnets, err = ParseClusterSubnetEntries(HybridOverlay.RawClusterSubnets)
+		_, HybridOverlay.ClusterSubnets, err = ParseClusterSubnetEntries(HybridOverlay.RawClusterSubnets)
 		if err != nil {
 			return fmt.Errorf("hybrid overlay cluster subnet invalid: %v", err)
 		}
@@ -1070,7 +1076,7 @@ func buildDefaultConfig(cli, file *config, allSubnets *configSubnets) error {
 	}
 
 	var err error
-	Default.ClusterSubnets, err = ParseClusterSubnetEntries(Default.RawClusterSubnets)
+	Default.ClusterSubnetsBySelector, Default.ClusterSubnets, err = ParseClusterSubnetEntries(Default.RawClusterSubnets)
 	if err != nil {
 		return fmt.Errorf("cluster subnet invalid: %v", err)
 	}

--- a/go-controller/pkg/config/utils_test.go
+++ b/go-controller/pkg/config/utils_test.go
@@ -111,7 +111,7 @@ func TestParseClusterSubnetEntries(t *testing.T) {
 
 	for _, tc := range tests {
 
-		parsedList, err := ParseClusterSubnetEntries(tc.cmdLineArg)
+		_, parsedList, err := ParseClusterSubnetEntries(tc.cmdLineArg)
 		if err != nil && !tc.expectedErr {
 			t.Errorf("Test case \"%s\" expected no errors, got %v", tc.name, err)
 		}

--- a/go-controller/pkg/ovn/gateway_test.go
+++ b/go-controller/pkg/ovn/gateway_test.go
@@ -74,7 +74,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
-			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node",
+			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node -- set logical_switch join_test-node other-config:subnet=100.64.0.0/29",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:01 100.64.0.1/29",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtod-test-node -- set logical_switch_port jtod-test-node type=router options:router-port=dtoj-test-node addresses=router",
@@ -140,7 +140,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=fd99::2 external_ids:physical_ips=fd99::2",
-			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node",
+			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node -- set logical_switch join_test-node other-config:ipv6_prefix=fd98::",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:fd:98:00:01 fd98::1/125",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtod-test-node -- set logical_switch_port jtod-test-node type=router options:router-port=dtoj-test-node addresses=router",
@@ -221,7 +221,7 @@ node4 chassis=912d592c-904c-40cd-9ef1-c2e5b49a33dd lb_force_snat_ip=100.64.0.4`,
 
 		fexec.AddFakeCmdsNoOutputNoError([]string{
 			"ovn-nbctl --timeout=15 -- --may-exist lr-add GR_test-node -- set logical_router GR_test-node options:chassis=SYSTEM-ID external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2,fd99::2",
-			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node",
+			"ovn-nbctl --timeout=15 -- --may-exist ls-add join_test-node -- set logical_switch join_test-node other-config:subnet=100.64.0.0/29 -- set logical_switch join_test-node other-config:ipv6_prefix=fd98::",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtor-GR_test-node -- set logical_switch_port jtor-GR_test-node type=router options:router-port=rtoj-GR_test-node addresses=router",
 			"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-GR_test-node -- lrp-add GR_test-node rtoj-GR_test-node 0a:58:64:40:00:01 100.64.0.1/29 fd98::1/125",
 			"ovn-nbctl --timeout=15 -- --may-exist lsp-add join_test-node jtod-test-node -- set logical_switch_port jtod-test-node type=router options:router-port=dtoj-test-node addresses=router",

--- a/go-controller/pkg/ovn/master_test.go
+++ b/go-controller/pkg/ovn/master_test.go
@@ -140,7 +140,7 @@ func defaultFakeExec(nodeSubnet, nodeName string, sctpSupport bool) (*ovntest.Fa
 
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
-		"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
+		"ovn-nbctl --timeout=15 --data=bare --no-heading --format=csv --columns=name,other-config,external_ids find logical_switch other-config:subnet!=_",
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
 		"ovn-nbctl --timeout=15 --if-exists lrp-del rtos-" + nodeName + " -- lrp-add ovn_cluster_router rtos-" + nodeName + " " + lrpMAC + " " + gwCIDR,
@@ -494,13 +494,10 @@ var _ = Describe("Master Operations", func() {
 				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
 			})
 			fexec.AddFakeCmd(&ovntest.ExpectedCmd{
-				Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
+				Cmd: "ovn-nbctl --timeout=15 --data=bare --no-heading --format=csv --columns=name,other-config,external_ids find logical_switch other-config:subnet!=_",
 				// Return two nodes
-				Output: fmt.Sprintf(`%s
-subnet=%s
-
-%s
-subnet=%s
+				Output: fmt.Sprintf(`%s,subnet=%s,
+%s,subnet=%s,
 `, node1Name, node1Subnet, masterName, masterSubnet),
 			})
 
@@ -733,7 +730,7 @@ var _ = Describe("Gateway Init Operations", func() {
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --format=csv --columns=name,other-config,external_ids find logical_switch other-config:subnet!=_",
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -754,7 +751,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-" + gwRouter + " -- lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",
@@ -782,7 +779,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=169.254.33.2 external_ids:physical_ips=169.254.33.2",
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-" + gwRouter + " -- lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",
@@ -918,7 +915,7 @@ var _ = Describe("Gateway Init Operations", func() {
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-sbctl --timeout=15 --data=bare --no-heading --columns=name,hostname --format=json list Chassis",
-				"ovn-nbctl --timeout=15 --data=bare --no-heading --columns=name,other-config find logical_switch other-config:subnet!=_",
+				"ovn-nbctl --timeout=15 --data=bare --no-heading --format=csv --columns=name,other-config,external_ids find logical_switch other-config:subnet!=_",
 			})
 
 			fexec.AddFakeCmdsNoOutputNoError([]string{
@@ -939,7 +936,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --if-exists remove logical_switch " + nodeName + " other-config exclude_ips",
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP + " external_ids:physical_ips=" + physicalGatewayIP,
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-" + gwRouter + " -- lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",
@@ -971,7 +968,7 @@ var _ = Describe("Gateway Init Operations", func() {
 			})
 			fexec.AddFakeCmdsNoOutputNoError([]string{
 				"ovn-nbctl --timeout=15 -- --may-exist lr-add " + gwRouter + " -- set logical_router " + gwRouter + " options:chassis=" + systemID + " external_ids:physical_ip=" + physicalGatewayIP + " external_ids:physical_ips=" + physicalGatewayIP,
-				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch,
+				"ovn-nbctl --timeout=15 -- --may-exist ls-add " + joinSwitch + " -- set logical_switch " + joinSwitch + " other-config:subnet=" + joinSubnet,
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtor-" + gwRouter + " -- set logical_switch_port jtor-" + gwRouter + " type=router options:router-port=rtoj-" + gwRouter + " addresses=router",
 				"ovn-nbctl --timeout=15 -- --if-exists lrp-del rtoj-" + gwRouter + " -- lrp-add " + gwRouter + " rtoj-" + gwRouter + " " + lrpMAC + " " + lrpIP + "/29",
 				"ovn-nbctl --timeout=15 -- --may-exist lsp-add " + joinSwitch + " jtod-" + nodeName + " -- set logical_switch_port jtod-" + nodeName + " type=router options:router-port=dtoj-" + nodeName + " addresses=router",

--- a/go-controller/pkg/ovn/ovn.go
+++ b/go-controller/pkg/ovn/ovn.go
@@ -70,8 +70,9 @@ type Controller struct {
 	watchFactory *factory.WatchFactory
 	stopChan     <-chan struct{}
 
-	masterSubnetAllocator *allocator.SubnetAllocator
-	joinSubnetAllocator   *allocator.SubnetAllocator
+	masterSubnetLabelSelector map[string]*metav1.LabelSelector
+	masterSubnetAllocator     map[string]*allocator.SubnetAllocator
+	joinSubnetAllocator       *allocator.SubnetAllocator
 
 	TCPLoadBalancerUUID  string
 	UDPLoadBalancerUUID  string
@@ -152,27 +153,28 @@ const (
 // infrastructure and policy
 func NewOvnController(kubeClient kubernetes.Interface, wf *factory.WatchFactory, stopChan <-chan struct{}) *Controller {
 	return &Controller{
-		kube:                     &kube.Kube{KClient: kubeClient},
-		watchFactory:             wf,
-		stopChan:                 stopChan,
-		masterSubnetAllocator:    allocator.NewSubnetAllocator(),
-		logicalSwitchCache:       make(map[string][]*net.IPNet),
-		joinSubnetAllocator:      allocator.NewSubnetAllocator(),
-		logicalPortCache:         newPortCache(stopChan),
-		namespaces:               make(map[string]*namespaceInfo),
-		namespacesMutex:          sync.Mutex{},
-		lspIngressDenyCache:      make(map[string]int),
-		lspEgressDenyCache:       make(map[string]int),
-		lspMutex:                 &sync.Mutex{},
-		lsMutex:                  &sync.Mutex{},
-		loadbalancerClusterCache: make(map[kapi.Protocol]string),
-		loadbalancerGWCache:      make(map[kapi.Protocol]string),
-		multicastSupport:         config.EnableMulticast,
-		serviceVIPToName:         make(map[ServiceVIPKey]types.NamespacedName),
-		serviceVIPToNameLock:     sync.Mutex{},
-		serviceLBMap:             make(map[string]map[string]*loadBalancerConf),
-		serviceLBLock:            sync.Mutex{},
-		recorder:                 util.EventRecorder(kubeClient),
+		kube:                      &kube.Kube{KClient: kubeClient},
+		watchFactory:              wf,
+		stopChan:                  stopChan,
+		masterSubnetLabelSelector: make(map[string]*metav1.LabelSelector),
+		masterSubnetAllocator:     make(map[string]*allocator.SubnetAllocator),
+		logicalSwitchCache:        make(map[string][]*net.IPNet),
+		joinSubnetAllocator:       allocator.NewSubnetAllocator(),
+		logicalPortCache:          newPortCache(stopChan),
+		namespaces:                make(map[string]*namespaceInfo),
+		namespacesMutex:           sync.Mutex{},
+		lspIngressDenyCache:       make(map[string]int),
+		lspEgressDenyCache:        make(map[string]int),
+		lspMutex:                  &sync.Mutex{},
+		lsMutex:                   &sync.Mutex{},
+		loadbalancerClusterCache:  make(map[kapi.Protocol]string),
+		loadbalancerGWCache:       make(map[kapi.Protocol]string),
+		multicastSupport:          config.EnableMulticast,
+		serviceVIPToName:          make(map[ServiceVIPKey]types.NamespacedName),
+		serviceVIPToNameLock:      sync.Mutex{},
+		serviceLBMap:              make(map[string]map[string]*loadBalancerConf),
+		serviceLBLock:             sync.Mutex{},
+		recorder:                  util.EventRecorder(kubeClient),
 	}
 }
 
@@ -602,6 +604,13 @@ func (oc *Controller) WatchNodes() error {
 
 			klog.V(5).Infof("Updated event for Node %q", node.Name)
 
+			newSelectorName := oc.getSubnetSelectorName(node)
+			oldSelectorName := oc.getSubnetSelectorName(oldNode)
+			if newSelectorName != oldSelectorName {
+				klog.Errorf("cannot change node label %s. subnet selector has been changed from %s to %s",
+					OvnNodeSubnetSelector, oldSelectorName, newSelectorName)
+			}
+
 			_, failed := mgmtPortFailed.Load(node.Name)
 			if failed || macAddressChanged(oldNode, node) {
 				err := oc.syncNodeManagementPort(node, nil)
@@ -631,9 +640,10 @@ func (oc *Controller) WatchNodes() error {
 			klog.V(5).Infof("Delete event for Node %q. Removing the node from "+
 				"various caches", node.Name)
 
+			selectorName := oc.getSubnetSelectorName(node)
 			nodeSubnets, _ := util.ParseNodeHostSubnetAnnotation(node)
 			joinSubnets, _ := util.ParseNodeJoinSubnetAnnotation(node)
-			err := oc.deleteNode(node.Name, nodeSubnets, joinSubnets)
+			err := oc.deleteNode(node.Name, selectorName, nodeSubnets, joinSubnets)
 			if err != nil {
 				klog.Error(err)
 			}


### PR DESCRIPTION
To specify specic subnet range for a specific node, first in the
ovn-config configmap, define multiple subnet cidrs in net_cidr with the
format of <cidr1>,<cidr2>@zone=<zone1>...; then label the node that that
needs specific subnet range with k8s.ovn.org/subnet_allocator_name=<zone1>
label.

Signed-off-by: Yun Zhou <yunz@nvidia.com>