### PR TITLE
ovn: fix several issues related to pod adding and deleting handling

### DIFF
--- a/go-controller/pkg/ovn/pods_test.go
+++ b/go-controller/pkg/ovn/pods_test.go
@@ -141,10 +141,10 @@ func (p pod) addCmdsForNonExistingPod(fexec *ovntest.FakeExec) {
 
 func (p pod) delCmds(fexec *ovntest.FakeExec) {
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID,
+		"ovn-nbctl --timeout=15 --if-exists lsp-del " + p.portName,
 	})
 	fexec.AddFakeCmdsNoOutputNoError([]string{
-		"ovn-nbctl --timeout=15 --if-exists lsp-del " + p.portName,
+		"ovn-nbctl --timeout=15 --if-exists remove port_group mcastPortGroupDeny ports " + fakeUUID,
 	})
 }
 
@@ -333,8 +333,8 @@ var _ = Describe("OVN Pod Operations", func() {
 					"10.128.1.2",
 					"10.128.1.1",
 					"myPod",
-					"10.128.1.3",
-					"0a:58:0a:80:01:03",
+					"10.128.1.4",
+					"0a:58:0a:80:01:04",
 					"namespace",
 				)
 


### PR DESCRIPTION
Today, delelteLogicalPort() verifies the existence of the Pod in
logicalPortCache before deleting the Pod's logical switch port, that
could cause stale logical switch port and also leaks its Pod IPs.

Also, an retried addLogicalPort() will try to reserve already
allocated Port IPs, which will fail.

This commit fixed both issues based on the assumption that Pod IPs
are allocated as long as the Pod's logical switch port is created
with its IP addresses set.

Signed-off-by: Yun Zhou <yunz@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-org/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Trivial changes are exempt from following this template.
If your change is non-trivial, please provide the following information:
-->

**- What this PR does and why is it needed**
<!--
A summary of the changes within this pull request and some context
as to why they were made
-->

**- Special notes for reviewers**
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->


**- How to verify it**
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->